### PR TITLE
Add tag external type

### DIFF
--- a/wasm/sections.ts
+++ b/wasm/sections.ts
@@ -30,6 +30,7 @@ export enum SectionKind {
   code = 'code',
   data = 'data',
   data_count = 'data count',
+  tag = 'tag'
 }
 
 export interface CustomSection {
@@ -184,7 +185,8 @@ export interface Export {
   | DescIndex<DescKind.funcidx>
   | DescIndex<DescKind.tableidx>
   | DescIndex<DescKind.memidx>
-  | DescIndex<DescKind.globalidx>;
+  | DescIndex<DescKind.globalidx>
+  | DescIndex<DescKind.tagidx>;
 }
 export function exportToString(exp: Export): string {
   return `${exp.name} (${descToString(exp.desc)})`;
@@ -200,6 +202,7 @@ export function readExportSection(r: Reader): Export[] {
         DescKind.tableidx,
         DescKind.memidx,
         DescKind.globalidx,
+        DescKind.tagidx,
       ] as const
     )[desc8];
     if (!kind) {

--- a/wasm/shared.ts
+++ b/wasm/shared.ts
@@ -7,12 +7,14 @@ export enum DescKind {
   table = 'table',
   mem = 'mem',
   global = 'global',
+  tag = 'tag',
 
   funcidx = 'funcidx',
   typeidx = 'typeidx',
   tableidx = 'tableidx',
   memidx = 'memidx',
   globalidx = 'globalidx',
+  tagidx = 'tagidx',
 }
 
 export interface DescTable {
@@ -39,7 +41,8 @@ type DescIndexKinds =
   | DescIndex<DescKind.typeidx>
   | DescIndex<DescKind.tableidx>
   | DescIndex<DescKind.memidx>
-  | DescIndex<DescKind.globalidx>;
+  | DescIndex<DescKind.globalidx>
+  | DescIndex<DescKind.tagidx>;
 
 export function descToString(
   desc: DescTable | DescMem | DescGlobal | DescIndexKinds,


### PR DESCRIPTION
Adds support for the tag export type:
https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/Tag

WASM exception support is fairly stable and supported in all browsers, even if it's typically behind a feature flag in compilers like Emscripten.